### PR TITLE
added terraref endpoint descriptor to sources

### DIFF
--- a/sources/TERRAREF.json
+++ b/sources/TERRAREF.json
@@ -1,0 +1,11 @@
+{
+  "@context": {
+    "schema": "http://schema.org/",
+    "brapi": "https://brapi.org/"
+  },
+  "@type": "schema:DataCatalog",
+  "@id": "https://terraref.org",
+  "schema:name": "TERRA REF",
+  "schema:identifier": "TERRA REF",
+  "brapi:endpointUrl": "https://brapi.workbench.terraref.org/brapi/v1/",
+}

--- a/sources/TERRAREF.json
+++ b/sources/TERRAREF.json
@@ -7,5 +7,5 @@
   "@id": "https://terraref.org",
   "schema:name": "TERRA REF",
   "schema:identifier": "TERRA REF",
-  "brapi:endpointUrl": "https://brapi.workbench.terraref.org/brapi/v1/",
+  "brapi:endpointUrl": "https://terraref.org/brapi/v1/",
 }


### PR DESCRIPTION
It would be great to have Elixir index metadata from the TERRA REF brapi endpoint. Please check that I have filled out the fields correctly, and let me know if there are any pre-requisites for being added to this list.