### PR TITLE
Fixed WUR url and startDate

### DIFF
--- a/config/transform-elasticsearch/documents/datadiscovery_study.json
+++ b/config/transform-elasticsearch/documents/datadiscovery_study.json
@@ -20,7 +20,7 @@
                 "possible_terms": [
                   "Phenotypes", "Phenotyping", "Field Experiement",
                   "Greenhouse (29\u00baC/20\u00baC)", "Green house",
-                  "Growth chamber", "Phenotyping Study"
+                  "Growth chamber", "Phenotyping Study", "raw"
                 ]
               },
               "{with}": {

--- a/config/transform-uri.json
+++ b/config/transform-uri.json
@@ -1,3 +1,6 @@
 {
-  "ignore-links": ["observation", "observationVariable", "trait", "breedingMethod", "method", "ontology", "scale", "studyType"]
+  "ignore-links": [
+    "observation", "observationVariable", "trait",
+    "breedingMethod", "method", "ontology", "scale",
+    "studyType", "crop"]
 }

--- a/etl/extract/brapi.py
+++ b/etl/extract/brapi.py
@@ -56,12 +56,15 @@ def fetch_all_in_store(entities, fetch_function, arguments, pool):
     """
     Run a fetch function with arguments in a pool worker and collect results in the entity MergeStore
     """
+    source_name = arguments[0][0]['schema:identifier']
     results = remove_empty(pool.imap_unordered(fetch_function, arguments, 4))
     if not results:
         return
 
     for (entity_name, data_list) in results:
         for data in data_list:
+            if source_name == 'WUR' and entity_name == 'study':
+                data['startDate'] = data['startDate'] + "-01-01"
             entities[entity_name]['store'].add(data)
 
 

--- a/etl/transform/uri.py
+++ b/etl/transform/uri.py
@@ -286,10 +286,14 @@ def transform_uri_link(source: dict, entities: dict, ignore_links,
             try:
                 return uri_index[link_id].decode()
             except KeyError as e:
-                raise MissingDataLink(
-                    f"Could not find '{alias or linked_entity}' with id '{link_id}' "
-                    f"found in '{link_path}' of object:\n{data}"
-                ) from e
+                try:
+                    # upper() to solve case sensitive issues (eg. "ea00371") in WUR data
+                    return uri_index[link_id.upper()].decode()
+                except KeyError as e:
+                    raise MissingDataLink(
+                        f"Could not find '{alias or linked_entity}' with id '{link_id}' "
+                        f"found in '{link_path}' of object:\n{data}"
+                    ) from e
         if plural:
             link_uri = list(map(get_in_index, link_value))
         else:

--- a/sources/WUR.json
+++ b/sources/WUR.json
@@ -7,27 +7,5 @@
   "@id": "https://www.eu-sol.wur.nl/",
   "schema:name": "WUR EU-SOL BreeDB",
   "schema:identifier": "WUR",
-  "brapi:endpointUrl": "https://www.eu-sol.wur.nl/webapi/brapi/v1/",
-
-  "-comment": "The following list is to be removed once WUR correctly implements the calls call",
-  "implemented-calls": [
-    "GET calls",
-    "GET crops",
-    "GET germplasm/{germplasmDbId}",
-    "GET germplasm/{germplasmDbId}/pedigree",
-    "GET germplasm/{germplasmDbId}/markerprofiles",
-    "GET germplasm-search",
-    "GET markerprofiles",
-    "GET trials",
-    "GET trials/{trialDbId}",
-    "GET traits",
-    "GET traits/{traitDbId}",
-    "GET programs",
-    "GET programs-search",
-    "GET studies-search",
-    "GET maps",
-    "GET maps/{mapDbId}",
-    "GET maps/{mapDbId}/positions/{linkageGroupName}",
-    "GET variables-search"
-  ]
+  "brapi:endpointUrl": "https://www.eu-sol.wur.nl/webapi/tomato/brapi/v1/"
 }


### PR DESCRIPTION
* Updated WUR brapi endpoint
* Fixed `startDate` type
*  Removed the `implemented-calls` field in `srource/WUR.json`

TODO:
In [Search Study by StudyDbId](https://brapi.docs.apiary.io/#reference/study/search/get-search-studies-by-searchresultsdbid) call ([example](https://www.eu-sol.wur.nl/webapi/tomato/brapi/v1/studies/34)):
- [ ] Ask about adding `documentationURL` field.
- [ ] Check if `germplasmbIds` (in `additionalInfo` object) is needed.